### PR TITLE
Gtk DisplayActionSheet fix

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/ActionSheetGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ActionSheetGallery.cs
@@ -26,6 +26,35 @@ namespace Xamarin.Forms.Controls
 				"Extra Eleven",
 			};
 
+
+			var extras25 = new string[] {
+				"Extra One",
+				"Extra Two",
+				"Extra Three",
+				"Extra Four",
+				"Extra Five",
+				"Extra Six",
+				"Extra Seven",
+				"Extra Eight",
+				"Extra Nine",
+				"Extra Ten",
+				"Extra Eleven",
+				"Extra Twelve",
+				"Extra Thirteen",
+				"Extra Fourteen",
+				"Extra Fifteen",
+				"Extra Sixteen",
+				"Extra Seventeen",
+				"Extra Eightteen",
+				"Extra Nineteen",
+				"Extra Twenty",
+				"Extra Twenty-one",
+				"Extra Twenty-two",
+				"Extra Twenty-three",
+				"Extra Twenty-four",
+				"Extra Twenty-five",
+			};
+
 			Content = new ScrollView {
 				Content = new StackLayout {
 					Spacing = 0,
@@ -45,6 +74,7 @@ namespace Xamarin.Forms.Controls
 						MakeActionSheetButton (this, "ActionSheet Title Destruction", "Title", null, "Destruction"),
 						MakeActionSheetButton (this, "ActionSheet Title Destruction Extras", "Title", null, "Destruction", extras),
 						MakeActionSheetButton (this, "ActionSheet Title Extras", "Title", null, null, extras),
+						MakeActionSheetButton (this, "ActionSheet Title Cancel Destruction 25xExtras", "Title", "Cancel", "Destruction", extras25),
 					}
 				}
 			};

--- a/Xamarin.Forms.Platform.GTK/Helpers/DialogHelper.cs
+++ b/Xamarin.Forms.Platform.GTK/Helpers/DialogHelper.cs
@@ -105,11 +105,11 @@ namespace Xamarin.Forms.Platform.GTK.Helpers
 
         private static void AddExtraButtons(ActionSheetArguments arguments, MessageDialog messageDialog)
         {
-            var vbox = messageDialog.VBox;
+            var newVBox = new VBox(messageDialog.VBox.Homogeneous, messageDialog.VBox.Spacing);
 
             // As we are not showing any message in this dialog, we just 
             // hide default container and avoid it from using space
-            vbox.Children[0].Hide();
+            messageDialog.VBox.Children[0].Hide();
 
             if (arguments.Buttons.Any())
             {
@@ -124,8 +124,24 @@ namespace Xamarin.Forms.Platform.GTK.Helpers
                     };
                     button.Show();
 
-                    vbox.PackStart(button, false, false, 0);
+                    newVBox.PackStart(button, false, false, 0);
                 }
+            }
+            newVBox.Show();
+
+            int maxScrollHeight = (int)(0.6 * messageDialog.Screen.Height);
+            if (newVBox.SizeRequest().Height >= maxScrollHeight) {
+                var scrolledWindow = new ScrolledWindow();
+                scrolledWindow.HscrollbarPolicy = PolicyType.Automatic;
+                scrolledWindow.VscrollbarPolicy = PolicyType.Always;
+                scrolledWindow.BorderWidth = 0;
+                scrolledWindow.HeightRequest = maxScrollHeight;
+                scrolledWindow.AddWithViewport(newVBox);
+                scrolledWindow.Show();
+
+                messageDialog.VBox.PackStart(scrolledWindow,false,false,0);
+            } else {
+                messageDialog.VBox.PackStart(newVBox,false,false,0);
             }
         }
     }

--- a/Xamarin.Forms.Platform.GTK/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/SliderRenderer.cs
@@ -37,6 +37,9 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                     // Use gtk.HScale, a horizontal slider widget for selecting a value from a range.
                     SetNativeControl(new Gtk.HScale(_minimum, _maximum, stepping));
                     Control.ValueChanged += OnControlValueChanged;
+
+                    // Hide the slider value (for consistency with other XF Platforms)
+                    Control.DrawValue = false;
                 }
 
                 UpdateMaximum();


### PR DESCRIPTION
### Description of Change ###

CHANGE 1
DisplayActionSheet on GTK had a bug if the number of buttons to show was large. The ActionSheet would be taller than the screen and some buttons and the cancel button were not visible.
This fix introduces a change to DisplayActionSheet on GTK so that the buttons are in a scroll window.
The same type of fix was needed in Xamarin Forms for MacOS recently.

CHANGE 2
The slider in GTK uses the native GTK widget that shows the numerical value of the slider.
It looks really nice but the other Xamarin Forms platforms do not show the value in the slider. They require the developer to create a User Interface showing the value.
So there is a patch to hide the numerical value on GTK.

### Bugs Fixed ###

CHANGE 1.
Bugzilla 58779 reported the bug for ActionSheets with a large number of buttons on MacOS. This ports the same fix to GTK

CHANGE 2
No bugzilla report generated

### API Changes ###

None


### Behavioral Changes ###

ActionSheets with a large number of buttons e.g. over 20 buttons will now have a scroll window with scroll bars instead of getting a truncated list.

The Slider no longer shows the numerical value and is consistent with sliders on other platforms.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
 is rebased on current upstream GTK fork
- [X] Changes adhere to coding standard
- [X] Consolidate commits as makes sense
